### PR TITLE
整个好活

### DIFF
--- a/kevinzonda_utility_rust/src/replacer/help_info.txt
+++ b/kevinzonda_utility_rust/src/replacer/help_info.txt
@@ -1,0 +1,7 @@
+KevinZonda.Utility.Rust.Replacer
+  --help | -h | -?
+    Get Help
+  --stdin | --pipeline | -p <from> <to>
+    Replace with pipeline
+  --string | -s <text> <from> <to>
+    Replace with string


### PR DESCRIPTION
- 变量可以先声明再初始化
- 错误处理一般统一用`Result`, 最后可以获得类似异常的效果
  - 好用的crates: `anyhow` 与 `thiserror`
- rust 有一些神奇的模式匹配与常量泛型, 试图用了一下可惜整活失败.
  模式匹配搭配上所有权, 声明周期啥的并不是很好用(所以gc真香)
  常量泛型限制还有一些大, 有些时候还不能用(比如函数既有常量泛型, 又有`impl Trait`参数的时候)
- 还有啥想说的忘了,想起来再加